### PR TITLE
Bug/dfc 9281 circuit breaker causes exceptions in sql

### DIFF
--- a/DFC.Digital.Tools/DFC.Digital.Tools.Function.EmailNotification/EmailNotificationProcessor.cs
+++ b/DFC.Digital.Tools/DFC.Digital.Tools.Function.EmailNotification/EmailNotificationProcessor.cs
@@ -105,6 +105,7 @@ namespace DFC.Digital.Tools.Function.EmailNotification
                         {
                             await accountsService.OpenCircuitBreakerAsync();
 
+                            //Set the all the accountsin the batch that did not get processed (sent ok)  to CircuitGotBroken
                             await accountsService.SetBatchToCircuitGotBrokenAsync(
                                 accountsToProcess.Where(notification => !notification.Processed));
                             break;

--- a/DFC.Digital.Tools/DFC.Digital.Tools.Repository.Accounts/Command/AuditCommandRepository.cs
+++ b/DFC.Digital.Tools/DFC.Digital.Tools.Repository.Accounts/Command/AuditCommandRepository.cs
@@ -42,7 +42,7 @@ namespace DFC.Digital.Tools.Repository.Accounts.Command
 
         public async Task SetBatchToCircuitGotBrokenAsync(IList<Account> accounts)
         {
-            var audits = accountsContext.Audit.Where(b => accounts.Any(a => a.EMail.Contains(b.Email))).ToList();
+            var audits = accountsContext.Audit.Where(b => accounts.Any(a => a.EMail.Contains(b.Email)) && b.Status == NotificationProcessingStatus.InProgress.ToString()).ToList();
             audits.ForEach(a => a.Status = NotificationProcessingStatus.CircuitGotBroken.ToString());
             await accountsContext.SaveChangesAsync();
         }


### PR DESCRIPTION
Changed to only update audits records to "CircuitGotBroken" for ones that have a status of "IsProcessing"